### PR TITLE
Dockerize 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+
+.git
+*Dockerfile*
+*docker-compose*
+node_modules
+.next/
+
+.vscode

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,10 @@
+# not ignoring node_modules to speed up builds for now to make use of npm-cache
+node_modules
 
 .git
 *Dockerfile*
 *docker-compose*
-node_modules
+
 .next/
 
 .vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# this file generates a very large image, because it uses full node image on debian
+# and because package.json is not optimized and pulls AFrame and three.js from github 
+# this is ok in development and internal builds initially and once optimized we can switch to 2-stage builds
+
 # not slim because we need github depedencies
 FROM node:12.16
 
@@ -14,8 +18,7 @@ ARG API_SERVER_URL=http://localhost:3030
 
 # copy then compile the code
 COPY . .
-RUN npm run compile
-RUN rm ./src -rf
+RUN npm run build
 
 ENV DEBUG *,-not_this,-express:*,-body-parser:*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,13 @@ COPY package*.json /app/
 #RUN  npm ci --verbose  # we should make lockfile or shrinkwrap then use npm ci for predicatble builds
 RUN  npm isntall --no-progress --verbose
 
-# Build Args
+# Build Args, NOTE: supplied at build time, not runtime
 ARG API_SERVER_URL=http://localhost:3030
 
 # copy then compile the code
 COPY . .
 RUN npm run build
 
-ENV DEBUG *,-not_this,-express:*,-body-parser:*
 
 EXPOSE 80
 CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# not slim because we need github depedencies
+FROM node:12.16
+
+# Create app directory
+WORKDIR /app
+
+# to make use of caching, copy only package files and install dependencies
+COPY package*.json /app/
+#RUN  npm ci --verbose  # we should make lockfile or shrinkwrap then use npm ci for predicatble builds
+RUN  npm isntall --no-progress --verbose
+
+# Build Args
+ARG API_SERVER_URL=http://localhost:3030
+
+# copy then compile the code
+COPY . .
+RUN npm run compile
+RUN rm ./src -rf
+
+ENV DEBUG *,-not_this,-express:*,-body-parser:*
+
+EXPOSE 80
+CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 # to make use of caching, copy only package files and install dependencies
 COPY package*.json /app/
 #RUN  npm ci --verbose  # we should make lockfile or shrinkwrap then use npm ci for predicatble builds
-RUN  npm isntall --no-progress --verbose
+RUN  npm install --no-progress --verbose
 
 # Build Args, NOTE: supplied at build time, not runtime
 ARG API_SERVER_URL=http://localhost:3030

--- a/README.md
+++ b/README.md
@@ -14,3 +14,25 @@ The client is built on Networked Aframe and React, and uses Nextjs for simplifie
 Typescript and strict linting are enforced
 
 TODO: Add all dependencies, explain each component and our decision to use, add links to tutorials
+
+
+## Docker
+
+You can run it using docker, if you don't have node installed or need to test.
+``` bash
+# Build the image
+docker build --tag xrchat-client .
+
+# Run the image (deletes itself when you close it)
+docker run -d --rm --name client -e "API_SERVER_URL=http://localhost:3030" -p "3000:3000"  xrchat-client
+
+# Stop the server
+docker stop client
+```
+
+### Docker image configurations
+
+This image uses build-time arguments, they are not used during runtime yet
+
+- `NODE_ENV` controls the config/*.js file to load and build against [default: production]
+- `API_SERVER_URL` points to an instance of the xrchat-server [default: http://localhost:3030]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/react-redux": "^7.1.7",
     "@types/redux-immutable": "^4.0.1",
     "@zeit/next-sass": "^1.0.1",
-    "aframe": "github:aframevr/aframe",
+    "aframe": "^1.0.4",
     "aframe-animation-component": "^5.1.2",
     "aframe-particle-system-component": "^1.1.3",
     "aframe-react": "^4.4.0",
@@ -25,7 +25,7 @@
     "glob": "^7.1.6",
     "immutable": "^4.0.0-rc.12",
     "isomorphic-unfetch": "3.0.0",
-    "networked-aframe": "github:networked-aframe/networked-aframe",
+    "networked-aframe": "^0.7.0",
     "next": "^9.3.4",
     "node-sass": "^4.13.1",
     "postcss-easy-import": "^3.0.0",
@@ -43,7 +43,7 @@
     "sass-loader": "^8.0.2",
     "socket.io-client": "^2.3.0",
     "socketio": "^1.0.0",
-    "three": "github:mrdoob/three.js",
+    "three": "^0.115.0",
     "webpack": "^4.42.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Dockerfile for client.

- I expect developers need to do some advanced stuff like pulling depednencies from git and so, so it used the full node.js image, not the slim one
- There is not package.lock.json yet, so I use "npm install"
- Uses Environment variables to modify build behaviour. this will need improvement once the configuration paramerts mature and are clear.
- I had to pin dependencies that use aframe and three.js from github. to make the build reproducable, so production releases will not use the bleeding edge from master.