### PR TITLE
Fixes external links for Portal entities

### DIFF
--- a/components/xr/portal/Portal.tsx
+++ b/components/xr/portal/Portal.tsx
@@ -2,7 +2,7 @@
 import { Entity } from 'aframe-react'
 import React from 'react'
 import { useRouter } from 'next/router'
-
+import isExternalUrl from 'utils/isExternalUrl'
 type makeHandleClickType = {
   href: string
   router: any
@@ -13,7 +13,11 @@ const makeHandleClick = ({ href, router }: makeHandleClickType) => {
     e.preventDefault()
     e.stopPropagation()
     console.log('clicked a link to', href, 'Here is the event:', e)
-    router.push(href)
+    if (isExternalUrl(href)) {
+      window.location.href = href
+    } else {
+      router.push(href)
+    }
   }
   return handleClick
 }

--- a/components/xr/portal/Portal.tsx
+++ b/components/xr/portal/Portal.tsx
@@ -2,6 +2,7 @@
 import { Entity } from 'aframe-react'
 import React from 'react'
 import { useRouter } from 'next/router'
+// @ts-ignore
 import isExternalUrl from 'utils/isExternalUrl'
 type makeHandleClickType = {
   href: string

--- a/next.config.js
+++ b/next.config.js
@@ -1,12 +1,14 @@
 const config = require('config')
 const withSass = require('@zeit/next-sass')
 const withImages = require('next-images')
+const path = require('path')
 
 module.exports = withImages(
   withSass({
     /* config options here */
     publicRuntimeConfig: config.publicRuntimeConfig,
     webpack(config, options) {
+      config.resolve.alias.utils = path.join(__dirname, 'utils')
       return config
     }
   })

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "test": "npm run build"
   },
   "dependencies": {
-    "utils": "link:./utils",
     "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
     "@feathersjs/authentication-client": "^4.5.2",
     "@feathersjs/client": "^4.5.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "with-typescript",
+  "name": "xrchat-client",
   "version": "1.0.0",
   "scripts": {
     "dev": "cross-env NODE_ENV=dev next --port $PORT",
@@ -9,6 +9,7 @@
     "test": "npm run build"
   },
   "dependencies": {
+    "utils": "link:./utils",
     "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
     "@feathersjs/authentication-client": "^4.5.2",
     "@feathersjs/client": "^4.5.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,13 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "esnext"
+    "target": "esnext",
+    "baseUrl": ".",
+    "paths": {
+       "utils/*": ["./utils/*"],
+    }
   },
   "exclude": ["node_modules"],
-  "include": ["**/*.ts", "**/*.tsx", "next.config.js"]
+  "include": ["**/*.ts", "**/*.tsx", "next.config.js"],
+
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,4 @@
   },
   "exclude": ["node_modules"],
   "include": ["**/*.ts", "**/*.tsx", "next.config.js"],
-
 }

--- a/utils/isExternalUrl.ts
+++ b/utils/isExternalUrl.ts
@@ -1,0 +1,8 @@
+// to determine if a url string is internal or external
+function isExternalUrl(url: string): boolean {
+  const externalProtocols = ['https://', 'http://', 'data:']
+  // if url starts with an external protocol
+  const isExternal = !!externalProtocols.find((protocol: string) => url.startsWith(protocol))
+  return isExternal
+}
+export default isExternalUrl


### PR DESCRIPTION
#110 #116 

Fixes external links for Portal entities.

In addition it modified next.config.js etc. for aliasing so that importing can use 'utils/utilFile' instead of '../../../../utils/utilFile' etc.