### PR TITLE
Explore pagination

### DIFF
--- a/components/xr/aframe/media-cell.tsx
+++ b/components/xr/aframe/media-cell.tsx
@@ -168,7 +168,7 @@ export const MediaCellComponent: AFRAME.ComponentDefinition<MediaCellProps> = {
           '&runtime=' + this.data.runtime +
           '&credit=' + this.data.productionCredit +
           '&rating=' + this.data.rating +
-          '&categories=' + this.data.categories.join(',') +
+          (Array.isArray(this.data.categories) ? '&categories=' + this.data.categories.join(', ') : this.data.categories.toString()) +
           // '&tags=' + this.data.tags.join(',') +
           '&videoformat=' + this.data.videoformat
         break

--- a/components/xr/scene/explore.tsx
+++ b/components/xr/scene/explore.tsx
@@ -66,7 +66,7 @@ const ExploreScene = (props: VideoProps): any => {
   const [videosArr, setVideosArr] = useState([])
   const [exploreState, setExploreState] = useState<ExploreState>({ focusedCellEl: null, focusedCell: null })
   const [pageOffset, setPageOffset] = useState(0)
-  const [visitedPages, setVisitedPages] = useState([0])
+  const [visitedPages, setVisitedPages] = useState([])
 
   const focusCell = (event: any) => {
     const focusCellEl = event.target.parentEl
@@ -91,10 +91,11 @@ const ExploreScene = (props: VideoProps): any => {
   }
 
   useEffect(() => {
-    if (videos.get('videos').size === 0) {
-      fetchPublicVideos()
+    // if this page was not visited before, fetch videos for next pages
+    if (!visitedPages.find(visitedPageOffset => visitedPageOffset === pageOffset)) {
+      fetchPublicVideos(pageOffset)
     }
-  }, [videos])
+  }, [visitedPages, pageOffset])
 
   useEffect(() => {
     document.addEventListener('backbutton', unFocusCell)
@@ -110,9 +111,6 @@ const ExploreScene = (props: VideoProps): any => {
   const pageRightHandler = () => {
     const nextPage = pageOffset + 1
     // if next page has not been visited before, fetch videos for the page
-    if (!visitedPages.find(pageOffset => pageOffset === nextPage)) {
-      fetchPublicVideos()
-    }
     setPageOffset(nextPage)
     setVisitedPages(pages => Array.from(new Set([...pages, nextPage])))
   }

--- a/components/xr/scene/explore.tsx
+++ b/components/xr/scene/explore.tsx
@@ -74,13 +74,13 @@ const ExploreScene = (props: VideoProps): any => {
       focusedCellEl: focusCellEl,
       focusedCell: {
         title: (focusCellEl.attributes as any).title.value,
-        description: (focusCellEl.attributes as any).description.value,
-        videoformat: (focusCellEl.attributes as any).videoformat.value,
+        description: (focusCellEl.attributes as any).description?.value,
+        videoformat: (focusCellEl.attributes as any).videoformat?.value,
         mediaUrl: (focusCellEl.attributes as any)['media-url'].value,
         thumbnailUrl: (focusCellEl.attributes as any)['thumbnail-url'].value,
         productionCredit: (focusCellEl.attributes as any)['production-credit'].value,
-        rating: (focusCellEl.attributes as any).rating.value,
-        categories: (focusCellEl.attributes as any).categories.value,
+        rating: (focusCellEl.attributes as any).rating?.value,
+        categories: (focusCellEl.attributes as any).categories?.value,
         runtime: (focusCellEl.attributes as any).runtime.value
       }
     })


### PR DESCRIPTION
#238 

/explore grid pagination with dynamically fetched videos.

Fixes a bug in media-cell.tsx where categories was treated as an array when it was actually a string.

Adds pageOffset back as an argument to fetchPublicVideos so videos are fetched for multiple pages.

Next step is store pageOffset in redux, so the last page is restored when navigating back to /explore.