### PR TITLE
loading screen for dreamscene and fixed lighting

### DIFF
--- a/components/xr/scene/dream-scene.tsx
+++ b/components/xr/scene/dream-scene.tsx
@@ -27,15 +27,19 @@ export default function DreamSceneScene(props: DreamSceneProps) {
   }, [loaded, gltfLoaded])
   return (
     <Entity>
-      {props.url && <Entity gltf-model={`url(${props.url})`} events={{
-        'model-error': err => {
-          console.error('Error loading gltf model', err)
-        },
-        'model-loaded': () => {
-          console.log('gltf model loaded.')
-          setGltfLoaded(true)
-        }
-      }} />}
+      {props.url &&
+      <Entity
+        primitive="a-gltf-model"
+        src={props.url}
+        events={{
+          'model-error': err => {
+            console.error('Error loading gltf model', err)
+          },
+          'model-loaded': () => {
+            console.log('gltf model loaded.')
+            setGltfLoaded(true)
+          }
+        }} />}
       <Lights />
       <Skybox />
     </Entity>

--- a/components/xr/scene/dream-scene.tsx
+++ b/components/xr/scene/dream-scene.tsx
@@ -1,21 +1,43 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Entity } from 'aframe-react'
 import Skybox from './skybox'
+import Lights from './lights'
 import './style.scss'
+import { useDispatch, useSelector } from 'react-redux'
+import { setAppLoaded } from '../../../redux/app/actions'
+import { selectAppState } from '../../../redux/app/selector'
 
 export interface DreamSceneProps {
   url: string
 }
-// TODO: make it render properly on navigation (appears black until refresh)
-// Maybe a solution is to set the gltf model as an asset-item dynamically
-// e.g. store gltf asset urls in redux, and render them in the assets.tsx from redux state
-// and add this url into redux on load
-// or it could just be some CORS texture loading issue?
+// loading progress bar is reset back to 0 as a result of this.
+// that might be ok if we can track progress of the gltf loading
+// we can edit the aframe source code (our xrchat/aframe version)
+// by registering onProgress callback here:
+// https://github.com/aframevr/aframe/blob/master/src/components/gltf-model.js#L35
+// emitting an event, and updating progress bar accordingly.
+// A fully solution could be to integrate this with assets loading bar so loading bar doesn't reset back to 0
 export default function DreamSceneScene(props: DreamSceneProps) {
+  const [gltfLoaded, setGltfLoaded] = useState(false)
+  const loaded = useSelector(state => selectAppState(state)).get('loaded')
+  const dispatch = useDispatch()
+  const setLoaded = loaded => dispatch(setAppLoaded(loaded))
+  useEffect(() => {
+    setLoaded(gltfLoaded)
+  }, [loaded, gltfLoaded])
   return (
     <Entity>
-      <a-gltf-model src={props.url}/>
-      <Skybox/>
+      {props.url && <Entity gltf-model={`url(${props.url})`} events={{
+        'model-error': err => {
+          console.error('Error loading gltf model', err)
+        },
+        'model-loaded': () => {
+          console.log('gltf model loaded.')
+          setGltfLoaded(true)
+        }
+      }} />}
+      <Lights />
+      <Skybox />
     </Entity>
   )
 }


### PR DESCRIPTION
#300 

Displays loading screen.

However, the loading bar is reset to 0 and we are not tracking loading progress of gltf models. Can we create a new issue for this?

This will involve editing xrchat/frame, specifically this file: https://github.com/aframevr/aframe/blob/master/src/components/gltf-model.js#L35
So that onProgress emits an event we can listen to.