### PR TITLE
Switched video posting from feathers client request to axios post.

### DIFF
--- a/components/ui/Admin/Console.tsx
+++ b/components/ui/Admin/Console.tsx
@@ -11,7 +11,6 @@ import Container from '@material-ui/core/Container'
 import { bindActionCreators, Dispatch } from 'redux'
 import { fetchAdminVideos } from '../../../redux/admin/service'
 import './admin.scss'
-import EmptyLayout from '../Layout/EmptyLayout'
 import { selectAdminState } from '../../../redux/admin/selector'
 import { selectVideoState } from '../../../redux/video/selector'
 import { selectAuthState } from '../../../redux/auth/selector'
@@ -89,7 +88,7 @@ const AdminConsole = (props: Props) => {
   }
 
   return (
-    <EmptyLayout>
+    <div>
       {auth.get('user').userRole === 'admin' && (
         <div className={'page-container'}>
           <div className={'header'}>
@@ -131,7 +130,7 @@ const AdminConsole = (props: Props) => {
           </Container>
         </div>
       )}
-    </EmptyLayout>
+    </div>
   )
 }
 

--- a/components/ui/Admin/VideoModal.tsx
+++ b/components/ui/Admin/VideoModal.tsx
@@ -17,7 +17,6 @@ import {
   deleteVideo
 } from '../../../redux/admin/service'
 import './admin.scss'
-import EmptyLayout from '../Layout/EmptyLayout'
 import { selectAdminState } from '../../../redux/admin/selector'
 interface Props {
   open: boolean
@@ -131,7 +130,7 @@ const VideoModal = (props: Props) => {
   }
 
   return (
-    <EmptyLayout>
+    <div>
       <Modal
         aria-labelledby="transition-modal-title"
         aria-describedby="transition-modal-description"
@@ -174,11 +173,12 @@ const VideoModal = (props: Props) => {
                   margin="normal"
                   required
                   fullWidth
-                  name="description"
-                  label="Description"
-                  id="description"
-                  autoComplete="description"
-                  defaultValue={state.description}
+                  name="url"
+                  label="Video URL"
+                  id="url"
+                  autoComplete="url"
+                  defaultValue={state.url}
+                  disabled={props.mode === 'edit' && true}
                   onChange={(e) => handleInput(e)}
                 />
               </Grid>
@@ -188,12 +188,11 @@ const VideoModal = (props: Props) => {
                   margin="normal"
                   required
                   fullWidth
-                  name="url"
-                  label="Video URL"
-                  id="url"
-                  autoComplete="url"
-                  defaultValue={state.url}
-                  disabled={props.mode === 'edit' && true}
+                  name="description"
+                  label="Description"
+                  id="description"
+                  autoComplete="description"
+                  defaultValue={state.description}
                   onChange={(e) => handleInput(e)}
                 />
               </Grid>
@@ -332,7 +331,7 @@ const VideoModal = (props: Props) => {
           </form>
         </div>
       </Modal>
-    </EmptyLayout>
+    </div>
   )
 }
 


### PR DESCRIPTION
The feathers client is connecting to the API server. This is fine for
most things, but video uploads need to go to the media server.
The quick solution was to make createVideo post an HTTP request to
/video so that the media server handles it.

Removed unneeded <EmptyLayouts> from admin console components since
they come with alert divs that we don't want.

Switched order of description and url inputs in video modal.